### PR TITLE
Refactor Maybe

### DIFF
--- a/Documentation.org
+++ b/Documentation.org
@@ -80,20 +80,38 @@ To construct a `Maybe a` value you can:
 
 #+begin_src php
 
-  $maybe = new Maybe(new Just(123));
-  $anotherMaybe = new Maybe(new Nothing());
+  $maybe = Maybe::just(123));
+
+  /** @var Maybe<int> */
+  $anotherMaybe = Maybe::nothing();
 
   $actualValue = $maybe->getValue(); // returns Just 123, so you can match the type
   $anotherActualvalue = $anotherMaybe->getValue();  // returns Nothing for the same reason
 
 #+end_src
 
-The object itself is a generic implementation but static analysis
-should be able to infer types, ie for the above it should be able to
-infer that it is Maybe<int>.
+In the case of Nothing, the annotation is required, otherwise the type
+is `Maybe<never>`.  However, it can be inferred from the function or
+method return type.
 
-TODO: See if that can work like that or user needs to extend Maybe to
-get consistency from static analysis. (getValue())
+#+begin_src php
+
+  /** @return Maybe<string> */
+  function mapToMaybe(?string $value): Maybe
+  {
+      if ($value === null) {
+          return Maybe::nothing();
+      }
+      return Maybe::just($value);
+  }
+
+  mapToMaybe(null); // Maybe<string>
+  mapToMaybe('something'); // Maybe<string>
+
+#+end_src
+
+TODO: What about extending Maybe (ie MaybeString) to get the type from
+static analysis. (getValue() will already have the correct type)
 
 ~Maybe~ implements ~Functor~ so you can apply a function to the underlying
 value, taking into account the Maybe logic (it will apply only when it
@@ -101,11 +119,11 @@ is Just).
 
 #+begin_src php
 
-  $maybe = new Maybe(new Just(123));
+  $maybe = Maybe::just(123));
   $maybeTimes34 = $maybe->fmap(fn ($x) => $x * 34);
   $result = $maybeTimes34->getValue();  // returns a Just(4182)
 
-  $maybe = new Maybe(new Nothing());
+  $maybe = Maybe::nothing();
   $maybeTimes34 = $maybe->fmap(fn ($x) => $x * 34);
   $result = $maybeTimes34->getValue(); // returns a Nothing
 
@@ -246,7 +264,7 @@ Functor laws.  Example usage:
   public function testIsAFunctor(): void
   {
       $this->assertInstanceIsFunctor(
-          new Maybe(new Just(5)),
+          Maybe::just(5),
           fn (int $x): bool => $x == 5,
           fn (bool $x): string => $x == true ? '100' : '500'
       );

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     ],
     "scripts": {
         "phpstan": "./vendor/bin/phpstan analyse src -c phpstan.neon",
+        "phpstan-types": "./vendor/bin/phpstan analyse tests/Phpstan -c phpstan.neon",
         "test": "./vendor/bin/phpunit tests --testdox --display-deprecations",
         "coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit tests --no-progress --coverage-text --strict-coverage --path-coverage",
         "coverage-no-path": "XDEBUG_MODE=coverage ./vendor/bin/phpunit tests --no-progress --coverage-text --strict-coverage",

--- a/src/Container/MethodContainer.php
+++ b/src/Container/MethodContainer.php
@@ -2,9 +2,7 @@
 
 namespace thgs\Functional\Container;
 
-use thgs\Functional\Data\Just;
 use thgs\Functional\Data\Maybe;
-use thgs\Functional\Data\Nothing;
 
 /**
  * Idea here is to have a quick and small inlined container rather than a
@@ -25,9 +23,7 @@ class MethodContainer
     {
         $typeClassMethods = $this->map[$method] ?? [];
         if (empty($typeClassMethods)) {
-            /** @var Maybe<Method> */
-            $return = new Maybe(new Nothing());
-            return $return;
+            return Maybe::nothing();
         }
 
         /** @phpstan-assert non-empty-array<Method> $typeClassInstances */
@@ -35,15 +31,13 @@ class MethodContainer
         if ($ofType instanceof TypeName)
             foreach ($typeClassMethods as $method)
                 if ($method->type->name == $ofType->name)
-                    return new Maybe(new Just($method));
+                    return Maybe::just($method);
 
         foreach ($typeClassMethods as $method)
             if ($method->predicate($ofType))
-                return new Maybe(new Just($method));
+                return Maybe::just($method);
 
-        /** @var Maybe<Method> */
-        $return = new Maybe(new Nothing());
-        return $return;
+        return Maybe::nothing();
     }
 
     /**
@@ -60,18 +54,11 @@ class MethodContainer
          * @todo Support multiple $ofType here and in the predicate?
          */
 
-        $maybeInstance = $this->getMethodImplementation($method, $ofType);
+        // todo: inline this for micro-optimisation?
 
-        // todo: fix maybe::unwrap or remove it -- its a mapping to nullable type
-
-        $foundInstance = $maybeInstance->getValue();
-        if ($foundInstance instanceof Nothing) {
-            return new Maybe(new Nothing());
-        }
-
-        return new Maybe(new Just(
-            $foundInstance->getValue()
-                ->invoke(...$arguments)));
+        return $this->getMethodImplementation($method, $ofType)
+            ->fmap(
+                fn (Method $method) => $method->invoke(...$arguments));
     }
 
     /**

--- a/src/Data/Maybe.php
+++ b/src/Data/Maybe.php
@@ -41,12 +41,32 @@ class Maybe implements
     SemigroupInstance,
     MonoidInstance
 {
-    public function __construct(
+    protected function __construct(
         /**
          * @var Nothing|Just<A1> $x
          */
         private readonly Nothing|Just $x
     ) {}
+
+    /**
+     * @template X1
+     * @param X1 $x
+     * @return Maybe<X1>
+     */
+    public static function just(mixed $x): Maybe
+    {
+        return new self(new Just($x));
+    }
+
+    /**
+     * @return Maybe<never>
+     */
+    public static function nothing(): Maybe
+    {
+        /** @var Maybe<never> */
+        $return = new self(new Nothing());
+        return $return;
+    }
 
     /**
      * @return Nothing|Just<A1>
@@ -59,6 +79,7 @@ class Maybe implements
     /**
      * @phpstan-assert-if-true Just<A1> $this->x
      * @phpstan-assert-if-true Just<A1> $this->getValue()
+     * @phpstan-assert-if-true A1 $this->unwrap()
      * @phpstan-assert-if-false Nothing $this->x
      */
     public function isJust(): bool

--- a/src/constructors.php
+++ b/src/constructors.php
@@ -4,10 +4,8 @@ namespace thgs\Functional;
 
 use thgs\Functional\Control\IO;
 use thgs\Functional\Data\Either;
-use thgs\Functional\Data\Just;
 use thgs\Functional\Data\Left;
 use thgs\Functional\Data\Maybe;
-use thgs\Functional\Data\Nothing;
 use thgs\Functional\Data\Right;
 use thgs\Functional\Data\Tuple;
 use thgs\Functional\Data\Tuple3;
@@ -20,18 +18,16 @@ use thgs\Functional\Data\Tuple3;
  */
 function just(mixed $x): Maybe
 {
-    return new Maybe(new Just($x));
+    return Maybe::just($x);
 }
 
 
 /**
- * @template X
- * @return Maybe<X>
+ * @return Maybe<never>
  */
 function nothing(): Maybe
 {
-    // @todo SA has an issue here
-    return new Maybe(new Nothing());
+    return Maybe::nothing();
 }
 
 

--- a/src/exception.php
+++ b/src/exception.php
@@ -2,10 +2,7 @@
 
 namespace thgs\Functional;
 
-
-use thgs\Functional\Data\Just;
 use thgs\Functional\Data\Maybe;
-use thgs\Functional\Data\Nothing;
 
 
 /**
@@ -18,13 +15,9 @@ use thgs\Functional\Data\Nothing;
 function safe(\Closure $f, mixed ...$xs): Maybe
 {
     try {
-        $value = new Maybe(new Just($f(...$xs)));
+        $value = Maybe::just($f(...$xs));
     } catch (\Throwable $e) {
-        /**
-         * Type hint because of Nothing
-         * @var Maybe<R> $value
-         */
-        $value = new Maybe(new Nothing());
+        $value = Maybe::nothing();
     }
     return $value;
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -10,6 +10,7 @@ use function thgs\Functional\const_;
 use function thgs\Functional\eq1;
 use function thgs\Functional\flip;
 use function thgs\Functional\fmap;
+use function thgs\Functional\just;
 use function thgs\Functional\memoize;
 use function thgs\Functional\unit;
 
@@ -19,7 +20,7 @@ class FunctionsTest extends TestCase
 
     public function testFmap(): void
     {
-        $data = new Maybe(new Just(5));
+        $data = just(5);
 
         // this fmap is :: (Int -> Bool) -> Maybe Int -> Maybe Bool
         $mapped = fmap(
@@ -42,7 +43,7 @@ class FunctionsTest extends TestCase
 
     public function testFmapWithComposition(): void
     {
-        $data = new Maybe(new Just(5));
+        $data = just(5);
 
         // this fmap is :: (Int -> Bool) -> Maybe Int -> Maybe Bool
         $mapped = fmap(
@@ -66,7 +67,7 @@ class FunctionsTest extends TestCase
     public function testShowWillTypeErrorWhenCannotShow(): void
     {
         $notShow = new class () { public int $a = 5; };
-        $data = new Maybe(new Just($notShow));
+        $data = just($notShow);
 
         $this->expectException(TypeError::class);
 
@@ -83,10 +84,10 @@ class FunctionsTest extends TestCase
             $callsCounter[$x] = isset($callsCounter[$x])
                 ? $callsCounter[$x] + 1
                 : 1;
-            
+
             return $x * $x;
         });
-        
+
         foreach (range(0,4) as $i) {
             $memoized($i);
         }
@@ -110,16 +111,16 @@ class FunctionsTest extends TestCase
             $callsCounter1[$x] = isset($callsCounter1[$x])
                 ? $callsCounter1[$x] + 1
                 : 1;
-            
+
             return $x * $x;
         });
-        
+
         $callsCounter2 = [];
         $memoized2 = memoize(function (int $x) use (&$callsCounter2) : int {
             $callsCounter2[$x] = isset($callsCounter2[$x])
                 ? $callsCounter2[$x] + 1
                 : 1;
-            
+
             return $x * $x;
         });
 

--- a/tests/MaybeTest.php
+++ b/tests/MaybeTest.php
@@ -21,7 +21,7 @@ class MaybeTest extends TestCase
 
     public function testFmap(): void
     {
-        $data = new Maybe(new Just(3));
+        $data = Maybe::just(3);
         $mapped = fmap(fn (int $x) => $x + 2, $data);
 
         $value = $mapped->getValue();
@@ -33,7 +33,7 @@ class MaybeTest extends TestCase
     public function testIsAFunctor(): void
     {
         $this->assertInstanceIsFunctor(
-            new Maybe(new Just(5)),
+            Maybe::just(5),
             fn (int $x): bool => $x == 5,
             fn (bool $x): string => $x == true ? '100' : '500'
         );
@@ -42,12 +42,12 @@ class MaybeTest extends TestCase
     public function testImplementsEqCorrectly(): void
     {
         $this->assertImplementsEqCorrectly(Maybe::pure(3), Maybe::pure(2));
-        $this->assertImplementsEqCorrectly(Maybe::pure(3), new Maybe(new Nothing()));
+        $this->assertImplementsEqCorrectly(Maybe::pure(3), Maybe::nothing());
     }
 
     public function testCanShow(): void
     {
-        $data = new Maybe(new Just(67));
+        $data = Maybe::just(67);
         $this->assertEquals('Just 67', show($data));
     }
 
@@ -55,7 +55,7 @@ class MaybeTest extends TestCase
     {
         // In PHP we have to go "in reverse", adding a constraint in the instances of Eq
 
-        $data = new Maybe(new Just(67));
+        $data = Maybe::just(67);
         $fiction = new class implements EqInstance {
             public function getValue()
             {
@@ -106,7 +106,7 @@ class MaybeTest extends TestCase
     public function testCanSequenceApplicativesWithNothing(): void
     {
         // Nothing <*> Just 67 :: Nothing
-        $apNothing = new Maybe(new Nothing());
+        $apNothing = Maybe::nothing();
         $ap2 = Maybe::pure(fn ($x) => $x + 3);
         $result = $apNothing->sequence($ap2);
         $this->assertInstanceOf(ApplicativeInstance::class, $result);
@@ -116,7 +116,7 @@ class MaybeTest extends TestCase
 
         // Just (+3) <*> Nothing :: Nothing
         $ap1 = Maybe::pure(fn ($x) => $x + 3);
-        $apNothing = new Maybe(new Nothing());
+        $apNothing = Maybe::nothing();
         $result = $ap1->sequence($apNothing);
         $this->assertInstanceOf(ApplicativeInstance::class, $result);
         $this->assertInstanceOf(Maybe::class, $result);

--- a/tests/MethodContainerTest.php
+++ b/tests/MethodContainerTest.php
@@ -7,6 +7,8 @@ use thgs\Functional\Container\Type;
 use thgs\Functional\Data\Just;
 use thgs\Functional\Data\Maybe;
 use thgs\Functional\Data\Nothing;
+use function thgs\Functional\just;
+use function thgs\Functional\nothing;
 use function thgs\Functional\partial;
 
 class MethodContainerTest extends TestCase
@@ -18,13 +20,13 @@ class MethodContainerTest extends TestCase
                                                 function (\Closure $f, Maybe $fa) {
                                                     $maybe = $fa->getValue();
                                                     if ($maybe instanceof Nothing) {
-                                                        return new Maybe(new Nothing());
+                                                        return nothing();
                                                     }
                                                     $result = partial($f, $maybe->getValue());
-                                                    return new Maybe(new Just($result));
+                                                    return just($result);
                                                 });
         $container = new MethodContainer();
-        $fa = new Maybe(new Just(3));
+        $fa = just(3);
         $container = $container->registerMethod($fmapForMaybe);
         $invokeResult = $container->invoke('fmap', $fa,
                                            // fmap arguments

--- a/tests/Phpstan/maybe.php
+++ b/tests/Phpstan/maybe.php
@@ -1,0 +1,167 @@
+<?php
+
+use thgs\Functional\Data\Just;
+use thgs\Functional\Data\Maybe;
+use thgs\Functional\Data\Nothing;
+use function PHPStan\Testing\assertType;
+use function thgs\Functional\just;
+use function thgs\Functional\nothing;
+
+/**
+ * -- Both constructions below (1,2) cannot possibly resolve string
+ * and that is fine.
+ *
+ * Therefore the constructor has been made protected.
+ */
+
+// Construction with objects (1)
+//assertType('thgs\Functional\Data\Maybe<string>', new Maybe(new Just('abc'))); // fine
+//assertType('thgs\Functional\Data\Maybe<mixed>',  new Maybe(new Nothing()));   // fine
+
+// Construction with functions (2)
+//assertType('thgs\Functional\Data\Maybe<string>', just('abc')); // fine
+//assertType('thgs\Functional\Data\Maybe<never>',  nothing());   // fine
+
+
+/**
+ * -- Assignment to a variable
+ */
+
+$maybe = Maybe::just('abc');
+assertType('thgs\Functional\Data\Maybe<string>', $maybe);
+
+/**
+ * Nothing without annotation (X=never)
+ */
+$maybeNothing = Maybe::nothing();
+assertType('thgs\Functional\Data\Maybe<never>', $maybeNothing);
+
+/**
+ * Required to annotate, which is fine.
+ *
+ * @var Maybe<string>
+ *
+ * Note, keep annotated variable to a different name otherwise it will
+ * interfere at Point A (see below).
+ */
+$mAnnotated = Maybe::nothing();
+assertType('thgs\Functional\Data\Maybe<string>', $mAnnotated);
+
+
+/**
+ * Mapping from nullable types category, within the context of
+ * a function.  Note that both return a `Maybe<string>`, which is
+ * exactly the goal.
+ */
+
+
+/**
+ * @return Maybe<string>
+ */
+function fromNullable(?string $x): Maybe
+{
+    if ($x !== null) {
+        return Maybe::just($x);
+    }
+
+    return Maybe::nothing();
+}
+
+/**
+ * @return Maybe<string>
+ */
+function fromNullableWithFunctions(?string $x): Maybe
+{
+    if ($x !== null) {
+        return just($x);
+    }
+
+    return nothing();
+}
+
+assertType('thgs\Functional\Data\Maybe<string>', fromNullable('abc')); // fine
+assertType('thgs\Functional\Data\Maybe<string>', fromNullable(null));  // fine
+
+assertType('thgs\Functional\Data\Maybe<string>', fromNullableWithFunctions('abc')); // fine
+assertType('thgs\Functional\Data\Maybe<string>', fromNullableWithFunctions(null));  // fine
+
+
+/**
+ * -- Getting the inner value
+ *
+ * Here we cannot resolve without an if-statement first (fine).
+ */
+
+$maybe = fromNullable('abc');
+assertType('thgs\Functional\Data\Just<string>|thgs\Functional\Data\Nothing', $maybe->getValue());
+
+$maybe = fromNullable(null);
+assertType('thgs\Functional\Data\Just<string>|thgs\Functional\Data\Nothing', $maybe->getValue());
+
+
+$maybe = fromNullable('abc');
+if ($maybe->isJust()) {
+    assertType('thgs\Functional\Data\Just<string>', $maybe->getValue());
+} else {
+    assertType('thgs\Functional\Data\Nothing', $maybe->getValue());
+}
+
+/**
+ * -- Unwrapping
+ *
+ * Here again we cannot resolve without an if-statement first (fine).
+ */
+
+$maybe = fromNullable('abc');
+assertType('string|null', $maybe->unwrap());
+
+$maybe = fromNullable(null);
+assertType('string|null', $maybe->unwrap());
+
+// Point A for reference.
+$maybe = fromNullable('abc');
+if ($maybe->isJust()) {
+    assertType('string', $maybe->unwrap());
+} else {
+    assertType('null', $maybe->unwrap());
+}
+
+
+/**
+ * -- Consuming a value
+ */
+
+/**
+ * @template X
+ * @param Maybe<X> $maybeValue
+ */
+function consumerForMaybe(Maybe $maybeValue): void
+{
+    // This is a little strange type, as `Maybe<X>` fails here.
+    assertType('thgs\Functional\Data\Maybe<X (function consumerForMaybe(), argument)>', $maybeValue);
+
+    // This is a little strange type
+    assertType('X (function consumerForMaybe(), argument)|null', $maybeValue->unwrap());
+}
+
+/**
+ * @template X of string
+ * @param Maybe<X> $maybeValue
+ */
+function consumerConstrainedForMaybe(Maybe $maybeValue): string
+{
+    // This is a little strange type, as `Maybe<X>` fails here.
+    assertType('thgs\Functional\Data\Maybe<X of string (function consumerConstrainedForMaybe(), argument)>', $maybeValue);
+
+    // This is a little strange type
+    assertType('X of string (function consumerConstrainedForMaybe(), argument)|null', $maybeValue->unwrap());
+
+    return $maybeValue->isJust() ? $maybeValue->unwrap() : 'Default string';
+}
+
+$return = consumerConstrainedForMaybe(fromNullable('abc'));
+assertType('string', $return);
+
+$return = consumerConstrainedForMaybe(fromNullable(null));
+assertType('string', $return);
+

--- a/tests/Typeclass/ShowTest.php
+++ b/tests/Typeclass/ShowTest.php
@@ -14,7 +14,7 @@ class ShowTest extends TestCase
             show: $showImplementation,
             instanceName: 'integer'
         );
-        
+
         $this->assertEquals('Integer 123', show(123));
     }
 


### PR DESCRIPTION
### Todo
- [x] Since types cannot be defined with manual construction let's make the constructor  protected and provide static constructors.
- [x] Mapping fromNullable cannot infer types on its own, a user level mapping has to exist.